### PR TITLE
Added timestamp, client IP and added failure for despawned pokemon

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,10 @@
 package main
 
 type Config struct {
-	Port    int                  `toml:"port"`
-	Golbat  golbatConfiguration  `toml:"golbat"`
-	Pokemon []templateDefinition `toml:"pokemon"`
+	Port            int                  `toml:"port"`
+	Golbat          golbatConfiguration  `toml:"golbat"`
+	Pokemon         []templateDefinition `toml:"pokemon"`
+	TimestampFormat string
 }
 
 type golbatConfiguration struct {

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	config.TimestampFormat = "2006-01-02 15:04:05"
 
 	//	templateStr := "https://maps.google.com/maps?q={{.lat}},{{.lon}}"
 
@@ -48,6 +49,6 @@ func main() {
 		Addr:    fmt.Sprintf(":%d", config.Port),
 		Handler: r,
 	}
-
+	fmt.Println("Starting server on port", config.Port)
 	srv.ListenAndServe()
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"text/template"
+    "time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pelletier/go-toml/v2"
@@ -49,6 +50,6 @@ func main() {
 		Addr:    fmt.Sprintf(":%d", config.Port),
 		Handler: r,
 	}
-	fmt.Println("Starting server on port", config.Port)
+	fmt.Printf("%s [] Starting server on port %d\n", time.Now().Format(config.TimestampFormat), config.Port)
 	srv.ListenAndServe()
 }

--- a/pokemon.go
+++ b/pokemon.go
@@ -24,7 +24,7 @@ func GetPokemon(c *gin.Context) {
 
 	if pokemonRecord == nil {
 		msg := "Unable to get location, the pokemon might have despawned\n"
-		fmt.Printf("%s [%s] %s", clientIP, time.Now().Format(config.TimestampFormat), msg)
+		fmt.Printf("%s [%s] %s", time.Now().Format(config.TimestampFormat), clientIP, msg)
 		c.Data(http.StatusNotFound, "application/json; charset=utf-8", []byte(msg))
 
 	} else {
@@ -32,7 +32,7 @@ func GetPokemon(c *gin.Context) {
 		err = pokemonTemplate.ExecuteTemplate(&doc, template, pokemonRecord)
 		_ = err
 		s := doc.String()
-		fmt.Printf("%s [%s] Redirecting to %s\n", clientIP, time.Now().Format(config.TimestampFormat), s)
+		fmt.Printf("%s [%s] Redirecting to %s\n", time.Now().Format(config.TimestampFormat), clientIP, s)
 		c.Redirect(http.StatusMovedPermanently, s)
 	}
 }

--- a/pokemon.go
+++ b/pokemon.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
@@ -15,10 +16,23 @@ func GetPokemon(c *gin.Context) {
 	var pokemonRecord any
 	err := getJson(fmt.Sprintf("%s/api/pokemon/id/%s", config.Golbat.Url, pokemonId), &pokemonRecord)
 
-	var doc bytes.Buffer
-	err = pokemonTemplate.ExecuteTemplate(&doc, template, pokemonRecord)
-	_ = err
-	s := doc.String()
-	fmt.Printf("Redirecting to %s\n", s)
-	c.Redirect(http.StatusMovedPermanently, s)
+	clientIP := c.GetHeader("CF-Connecting-IP")
+	// fallback if someone is not using cloudflare
+	if clientIP == "" {
+		clientIP = c.ClientIP()
+	}
+
+	if pokemonRecord == nil {
+		msg := "Unable to get location, the pokemon might have despawned\n"
+		fmt.Printf("%s [%s] %s", clientIP, time.Now().Format(config.TimestampFormat), msg)
+		c.Data(http.StatusNotFound, "application/json; charset=utf-8", []byte(msg))
+
+	} else {
+		var doc bytes.Buffer
+		err = pokemonTemplate.ExecuteTemplate(&doc, template, pokemonRecord)
+		_ = err
+		s := doc.String()
+		fmt.Printf("%s [%s] Redirecting to %s\n", clientIP, time.Now().Format(config.TimestampFormat), s)
+		c.Redirect(http.StatusMovedPermanently, s)
+	}
 }

--- a/pokemon.go
+++ b/pokemon.go
@@ -13,14 +13,14 @@ func GetPokemon(c *gin.Context) {
 	pokemonId := c.Param("pokemon_id")
 	template := c.Param("template")
 
-	var pokemonRecord any
-	err := getJson(fmt.Sprintf("%s/api/pokemon/id/%s", config.Golbat.Url, pokemonId), &pokemonRecord)
-
 	clientIP := c.GetHeader("CF-Connecting-IP")
 	// fallback if someone is not using cloudflare
 	if clientIP == "" {
 		clientIP = c.ClientIP()
 	}
+
+	var pokemonRecord any
+	err := getJson(fmt.Sprintf("%s/api/pokemon/id/%s", config.Golbat.Url, pokemonId), &pokemonRecord)
 
 	if pokemonRecord == nil {
 		msg := "Unable to get location, the pokemon might have despawned\n"


### PR DESCRIPTION
Added some stuff @dkmur mentioned. Not 100% ideal way to add it but project scope is quite small at the moment so hope this will suffice for now.

I did not have a golbat db to test out the successful pokemon record grab, so instead I inverted the `if pokemonRecord == nil` msg to test. 

Logging format
```
arniethepie@jellydog:~/signpost$ ./signpost
Starting server on port 1234
192.168.1.203 [2024-02-09 01:41:34] Unable to get location, the pokemon might have despawned
86.x.x.x [2024-02-09 01:42:34] Unable to get location, the pokemon might have despawned
86.x.x.x [2024-02-09 01:45:24] Redirecting to https://maps.google.com/maps?q=X,X
```