### PR TITLE
Update Apple Maps URL to use place endpoint

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -15,4 +15,4 @@ url="https://www.waze.com/ul?ll={{.lat}},{{.lon}}&navigate=yes&zoom=17"
 
 [[pokemon]]
 name="apple"
-url="https://maps.apple.com/maps?daddr={{.lat}},{{.lon}}"
+url="https://maps.apple.com/place?coordinate={{.lat}},{{.lon}}"


### PR DESCRIPTION
Updated the example config file with new Apple URL endpoint like we have done in [ReactMap](https://github.com/WatWowMap/ReactMap/pull/1104) and [Poracle](https://github.com/KartulUdus/PoracleJS/pull/923)