### PR TITLE
Pokestop and Gym Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,21 @@ Update your DTS templates to use Signpost. The links in your templates should lo
 
 Pokemon:
 ```
-[Google](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/google>)
-[Apple](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/apple>)
-[Waze](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/waze>)
+[Google](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/google>)
+[Apple](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/apple>)
+[Waze](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/waze>)
 ```
 
 Pokestops:
 ```
-[Google](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/google>)
-[Apple](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/apple>)
-[Waze](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/waze>)
+[Google](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/google>)
+[Apple](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/apple>)
+[Waze](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/waze>)
 ```
 
 Gyms:
 ```
-[Google](<https://signpost.yourmap.com/gym/{{gym_id}}/google>)
-[Apple](<https://signpost.yourmap.com/gym/{{gym_id}}/apple>)
-[Waze](<https://signpost.yourmap.com/gym/{{gym_id}}/waze>)
+[Google](<https://signpost.yourmap.com/gym/{{{gym_id}}}/google>)
+[Apple](<https://signpost.yourmap.com/gym/{{{gym_id}}}/apple>)
+[Waze](<https://signpost.yourmap.com/gym/{{{gym_id}}}/waze>)
 ```

--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ https://signpost.yourmap.com/pokemon/1782929313465823/google
 # Poracle DTS Changes
 Update your Pokemon DTS templates to use Signpost. The links in your templates should look something like this:
 ```
-[Google](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/google>)
-[Apple](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/apple>)
-[Waze](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/waze>)
+[Google](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/google>)
+[Apple](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/apple>)
+[Waze](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/waze>)
 ```
 
 Similarly, you can update your Pokestop DTS templates. The links in your templates should look something like this:
 ```
-[Google](<https://signpost.yourmap.com/pokestop/{{{[pokestop_id]}}}/google>)
-[Apple](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/apple>)
-[Waze](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/waze>)
+[Google](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/google>)
+[Apple](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/apple>)
+[Waze](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/waze>)
 ```
 ⚠️ Don't adjust the URLs for Gyms as they are currently not supported.

--- a/README.md
+++ b/README.md
@@ -40,4 +40,11 @@ Update your Pokemon DTS templates to use Signpost. The links in your templates s
 [Apple](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/apple>)
 [Waze](<https://signpost.yourmap.com/pokemon/{{{encounter_id}}}/waze>)
 ```
-⚠️ Don't adjust the URLs for Pokestops/Gyms as they are currently not supported.
+
+Similarly, you can update your Pokestop DTS templates. The links in your templates should look something like this:
+```
+[Google](<https://signpost.yourmap.com/pokestop/{{{[pokestop_id]}}}/google>)
+[Apple](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/apple>)
+[Waze](<https://signpost.yourmap.com/pokestop/{{{pokestop_id}}}/waze>)
+```
+⚠️ Don't adjust the URLs for Gyms as they are currently not supported.

--- a/README.md
+++ b/README.md
@@ -34,17 +34,25 @@ https://signpost.yourmap.com/pokemon/1782929313465823/google
 3. `pm2 restart signpost`
 
 # Poracle DTS Changes
-Update your Pokemon DTS templates to use Signpost. The links in your templates should look something like this:
+Update your DTS templates to use Signpost. The links in your templates should look something like this:
+
+Pokemon:
 ```
 [Google](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/google>)
 [Apple](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/apple>)
 [Waze](<https://signpost.yourmap.com/pokemon/{{encounter_id}}/waze>)
 ```
 
-Similarly, you can update your Pokestop DTS templates. The links in your templates should look something like this:
+Pokestops:
 ```
 [Google](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/google>)
 [Apple](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/apple>)
 [Waze](<https://signpost.yourmap.com/pokestop/{{pokestop_id}}/waze>)
 ```
-⚠️ Don't adjust the URLs for Gyms as they are currently not supported.
+
+Gyms:
+```
+[Google](<https://signpost.yourmap.com/gym/{{gym_id}}/google>)
+[Apple](<https://signpost.yourmap.com/gym/{{gym_id}}/apple>)
+[Waze](<https://signpost.yourmap.com/gym/{{gym_id}}/waze>)
+```

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ type Config struct {
 	Golbat          golbatConfiguration  `toml:"golbat"`
 	Pokemon         []templateDefinition `toml:"pokemon"`
 	Pokestop        []templateDefinition `toml:"pokestop"`
+	Gym             []templateDefinition `toml:"gym"`
 	TimestampFormat string
 }
 

--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ type Config struct {
 	Port            int                  `toml:"port"`
 	Golbat          golbatConfiguration  `toml:"golbat"`
 	Pokemon         []templateDefinition `toml:"pokemon"`
+	Pokestop        []templateDefinition `toml:"pokestop"`
 	TimestampFormat string
 }
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -16,3 +16,15 @@ url="https://www.waze.com/ul?ll={{.lat}},{{.lon}}&navigate=yes&zoom=17"
 [[pokemon]]
 name="apple"
 url="https://maps.apple.com/place?coordinate={{.lat}},{{.lon}}"
+
+[[pokestop]]
+name="google"
+url="https://maps.google.com/maps?q={{.lat}},{{.lon}}&z=17"
+
+[[pokestop]]
+name="waze"
+url="https://www.waze.com/ul?ll={{.lat}},{{.lon}}&navigate=yes&zoom=17"
+
+[[pokestop]]
+name="apple"
+url="https://maps.apple.com/place?coordinate={{.lat}},{{.lon}}"

--- a/config.toml.example
+++ b/config.toml.example
@@ -28,3 +28,15 @@ url="https://www.waze.com/ul?ll={{.lat}},{{.lon}}&navigate=yes&zoom=17"
 [[pokestop]]
 name="apple"
 url="https://maps.apple.com/place?coordinate={{.lat}},{{.lon}}"
+
+[[gym]]
+name="google"
+url="https://maps.google.com/maps?q={{.lat}},{{.lon}}&z=17"
+
+[[gym]]
+name="waze"
+url="https://www.waze.com/ul?ll={{.lat}},{{.lon}}&navigate=yes&zoom=17"
+
+[[gym]]
+name="apple"
+url="https://maps.apple.com/place?coordinate={{.lat}},{{.lon}}"

--- a/gym.go
+++ b/gym.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+func GetGym(c *gin.Context) {
+	gymId := c.Param("gym_id")
+	template := c.Param("template")
+
+	clientIP := c.GetHeader("CF-Connecting-IP")
+	// fallback if someone is not using cloudflare
+	if clientIP == "" {
+		clientIP = c.ClientIP()
+	}
+
+	var gymRecord any
+	err := getJson(fmt.Sprintf("%s/api/gym/id/%s", config.Golbat.Url, gymId), &gymRecord)
+
+	if gymRecord == nil {
+		msg := "Unable to get location, the gym might not exist\n"
+		fmt.Printf("%s [%s] %s", time.Now().Format(config.TimestampFormat), clientIP, msg)
+		c.Data(http.StatusNotFound, "application/json; charset=utf-8", []byte(msg))
+
+	} else {
+		var doc bytes.Buffer
+		err = gymTemplate.ExecuteTemplate(&doc, template, gymRecord)
+		_ = err
+		s := doc.String()
+		fmt.Printf("%s [%s] Redirecting to %s\n", time.Now().Format(config.TimestampFormat), clientIP, s)
+		c.Redirect(http.StatusMovedPermanently, s)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ func main() {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.GET("/pokemon/:pokemon_id/:template", GetPokemon)
+	r.GET("/pokestop/:pokestop_id/:template", GetPokestop)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 var pokemonTemplate *template.Template
 var pokestopTemplate *template.Template
+var gymTemplate *template.Template
 
 func main() {
 	tomlFile, err := os.Open("config.toml")
@@ -36,6 +37,7 @@ func main() {
 
 	pokemonTemplate = template.New("pokemon")
 	pokestopTemplate = template.New("pokestop")
+	gymTemplate = template.New("gym")
 
 	for _, t := range config.Pokemon {
 		pokemonTemplate, err = pokemonTemplate.New(t.Name).Parse(t.Url)
@@ -51,10 +53,18 @@ func main() {
 		}
 	}
 
+	for _, t := range config.Gym {
+		gymTemplate, err = gymTemplate.New(t.Name).Parse(t.Url)
+		if err != nil {
+			panic(err)
+		}
+	}
+
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
 	r.GET("/pokemon/:pokemon_id/:template", GetPokemon)
 	r.GET("/pokestop/:pokestop_id/:template", GetPokestop)
+	r.GET("/gym/:gym_id/:template", GetGym)
 
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Port),

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 var pokemonTemplate *template.Template
+var pokestopTemplate *template.Template
 
 func main() {
 	tomlFile, err := os.Open("config.toml")
@@ -34,9 +35,17 @@ func main() {
 	//	templateStr := "https://maps.google.com/maps?q={{.lat}},{{.lon}}"
 
 	pokemonTemplate = template.New("pokemon")
+	pokestopTemplate = template.New("pokestop")
 
 	for _, t := range config.Pokemon {
 		pokemonTemplate, err = pokemonTemplate.New(t.Name).Parse(t.Url)
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	for _, t := range config.Pokestop {
+		pokestopTemplate, err = pokestopTemplate.New(t.Name).Parse(t.Url)
 		if err != nil {
 			panic(err)
 		}

--- a/pokemon.go
+++ b/pokemon.go
@@ -36,3 +36,31 @@ func GetPokemon(c *gin.Context) {
 		c.Redirect(http.StatusMovedPermanently, s)
 	}
 }
+
+func GetPokestop(c *gin.Context) {
+	pokestopId := c.Param("pokestop_id")
+	template := c.Param("template")
+
+	clientIP := c.GetHeader("CF-Connecting-IP")
+	// fallback if someone is not using cloudflare
+	if clientIP == "" {
+		clientIP = c.ClientIP()
+	}
+
+	var pokestopRecord any
+	err := getJson(fmt.Sprintf("%s/api/pokestop/id/%s", config.Golbat.Url, pokestopId), &pokestopRecord)
+
+	if pokestopRecord == nil {
+		msg := "Unable to get location, the pokestop might not exist\n"
+		fmt.Printf("%s [%s] %s", time.Now().Format(config.TimestampFormat), clientIP, msg)
+		c.Data(http.StatusNotFound, "application/json; charset=utf-8", []byte(msg))
+
+	} else {
+		var doc bytes.Buffer
+		err = pokemonTemplate.ExecuteTemplate(&doc, template, pokestopRecord)
+		_ = err
+		s := doc.String()
+		fmt.Printf("%s [%s] Redirecting to %s\n", time.Now().Format(config.TimestampFormat), clientIP, s)
+		c.Redirect(http.StatusMovedPermanently, s)
+	}
+}

--- a/pokestop.go
+++ b/pokestop.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func GetPokemon(c *gin.Context) {
-	pokemonId := c.Param("pokemon_id")
+func GetPokestop(c *gin.Context) {
+	pokestopId := c.Param("pokestop_id")
 	template := c.Param("template")
 
 	clientIP := c.GetHeader("CF-Connecting-IP")
@@ -19,17 +19,17 @@ func GetPokemon(c *gin.Context) {
 		clientIP = c.ClientIP()
 	}
 
-	var pokemonRecord any
-	err := getJson(fmt.Sprintf("%s/api/pokemon/id/%s", config.Golbat.Url, pokemonId), &pokemonRecord)
+	var pokestopRecord any
+	err := getJson(fmt.Sprintf("%s/api/pokestop/id/%s", config.Golbat.Url, pokestopId), &pokestopRecord)
 
-	if pokemonRecord == nil {
-		msg := "Unable to get location, the pokemon might have despawned\n"
+	if pokestopRecord == nil {
+		msg := "Unable to get location, the pokestop might not exist\n"
 		fmt.Printf("%s [%s] %s", time.Now().Format(config.TimestampFormat), clientIP, msg)
 		c.Data(http.StatusNotFound, "application/json; charset=utf-8", []byte(msg))
 
 	} else {
 		var doc bytes.Buffer
-		err = pokemonTemplate.ExecuteTemplate(&doc, template, pokemonRecord)
+		err = pokestopTemplate.ExecuteTemplate(&doc, template, pokestopRecord)
 		_ = err
 		s := doc.String()
 		fmt.Printf("%s [%s] Redirecting to %s\n", time.Now().Format(config.TimestampFormat), clientIP, s)


### PR DESCRIPTION
Created a new function to add support for Pokestops, similarly to Pokemon.

Accessed from Golbat API. Can be utilized in a similar manner, such as 
```https://signpost.yourmap.com/pokestop/{{pokestop_id}}/google```

Also, updated the README accordingly to reflect this new information, as well as making minor adjustments to accuracy of existing information.

Tested and working on my own implementation, verified by subscribers.

Unsure if gym support is possible though without tapping the db directly, as it does not seem like there are any endpoints in Golbat currently available for this.